### PR TITLE
Latest updates

### DIFF
--- a/src/bamboo/trove/common/ContentThreshold.java
+++ b/src/bamboo/trove/common/ContentThreshold.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.common;
 
 /**

--- a/src/bamboo/trove/common/DocumentStatus.java
+++ b/src/bamboo/trove/common/DocumentStatus.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.common;
 
 public enum DocumentStatus {

--- a/src/bamboo/trove/common/DocumentStatus.java
+++ b/src/bamboo/trove/common/DocumentStatus.java
@@ -18,5 +18,7 @@ package bamboo.trove.common;
 public enum DocumentStatus {
   ACCEPTED,
   REJECTED,
-  RESTRICTED
+  RESTRICTED_FOR_DELIVERY,
+  RESTRICTED_FOR_DISCOVERY,
+  RESTRICTED_FOR_BOTH
 }

--- a/src/bamboo/trove/common/IndexerDocument.java
+++ b/src/bamboo/trove/common/IndexerDocument.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.common;
 
 import au.gov.nla.trove.indexer.api.AcknowledgeWorker;

--- a/src/bamboo/trove/common/SolrEnum.java
+++ b/src/bamboo/trove/common/SolrEnum.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.common;
 
 public enum SolrEnum {

--- a/src/bamboo/trove/common/SolrEnum.java
+++ b/src/bamboo/trove/common/SolrEnum.java
@@ -22,7 +22,8 @@ public enum SolrEnum {
   TITLE("title"),
   CONTENT_TYPE("contentType"),
   SITE("site"),
-  RESTRICTED("restricted");
+  DELIVERABLE("deliverable"),
+  DISCOVERABLE("discoverable");
 
   private String value;
   SolrEnum(String value) {

--- a/src/bamboo/trove/common/WarcProgressManager.java
+++ b/src/bamboo/trove/common/WarcProgressManager.java
@@ -15,6 +15,7 @@
  */
 package bamboo.trove.common;
 
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Timer;
@@ -33,19 +34,25 @@ public class WarcProgressManager {
 
   // Queues for progress monitoring - single threaded access
   private Queue<IndexerDocument> filterProgress = new LinkedList<>();
+  private int countFilterCompleted = 0;
   private Queue<IndexerDocument> transformProgress = new LinkedList<>();
+  private int countTransformCompleted = 0;
   private Queue<IndexerDocument> indexProgress = new LinkedList<>();
+  private int countIndexCompleted = 0;
   // Error queue
-  private BlockingQueue<IndexerDocument> errorQ = new ArrayBlockingQueue<>(5);
-  private int discardedErrors = 0;
+  protected BlockingQueue<IndexerDocument> errorQ = new ArrayBlockingQueue<>(5);
+  protected int discardedErrors = 0;
 
   // Batch state
+  private long timeStarted;
   private boolean filterComplete = false;
   private boolean transformComplete = false;
   private boolean indexComplete = false;
   private Timer timer;
   private int batchSize = 0;
+  private long batchBytes = 0;
   private boolean loadingComplete = false;
+  private boolean loadingFailed = false;
 
   // Sometimes we will be asked to hold a reference to a particular document
   private IndexerDocument trackedDocument = null;
@@ -54,7 +61,16 @@ public class WarcProgressManager {
   public WarcProgressManager(long warcId, long trackedOffset) {
     this.warcId = warcId;
     this.trackedOffset = trackedOffset;
+    this.timeStarted = new Date().getTime();
     checkQueues();
+  }
+
+  public long getWarcId() {
+    return warcId;
+  }
+
+  public long getTimeStarted() {
+    return timeStarted;
   }
 
   public IndexerDocument add(Document document) {
@@ -77,43 +93,75 @@ public class WarcProgressManager {
     return trackedDocument;
   }
 
+  public boolean isLoadingComplete() {
+    return loadingComplete;
+  }
+
   public void setLoadComplete() {
     loadingComplete = true;
   }
 
-  private void enqueueDocument(IndexerDocument document) {
+  public boolean isLoadingFailed() {
+    return loadingFailed;
+  }
+
+  public void setLoadFailed() {
+    loadingFailed = true;
+  }
+
+  private synchronized void enqueueDocument(IndexerDocument document) {
     filterProgress.add(document);
     transformProgress.add(document);
     indexProgress.add(document);
     batchSize++;
   }
 
-  private void checkQueues() {
+  private synchronized void checkQueues() {
     // Filtering
     while (filterProgress.peek() != null && filterProgress.peek().filter.hasFinished()) {
-      hasNoErrors(filterProgress.remove());
-    }
-    if (loadingComplete && filterProgress.isEmpty()) {
-      filterComplete = true;
+      if (hasNoErrors(filterProgress.remove())) {
+        countFilterCompleted++;
+      }
     }
 
     // Transforming
     while (transformProgress.peek() != null && transformProgress.peek().transform.hasFinished()) {
-      hasNoErrors(transformProgress.remove());
-    }
-    if (loadingComplete && transformProgress.isEmpty()) {
-      transformComplete = true;
+      if (hasNoErrors(transformProgress.remove())) {
+        countTransformCompleted++;
+      }
     }
 
     // Indexing
     while (indexProgress.peek() != null && indexProgress.peek().index.hasFinished()) {
-      hasNoErrors(indexProgress.remove());
-    }
-    if (loadingComplete && indexProgress.isEmpty()) {
-      indexComplete = true;
+      if (hasNoErrors(indexProgress.remove())) {
+        countIndexCompleted++;
+      }
     }
 
-    if (!filterComplete || !transformComplete || !indexComplete) {
+    if (loadingComplete || loadingFailed) {
+      // Would this occur?
+      if (filterProgress.peek() == null && !filterProgress.isEmpty()) {
+        log.error("Null object in queue! filterProgress: {}", this.warcId);
+      }
+      if (transformProgress.peek() == null && !transformProgress.isEmpty()) {
+        log.error("Null object in queue! transformProgress: {}", this.warcId);
+      }
+      if (indexProgress.peek() == null && !indexProgress.isEmpty()) {
+        log.error("Null object in queue! indexProgress: {}", this.warcId);
+      }
+
+      if (filterProgress.isEmpty()) {
+        filterComplete = true;
+      }
+      if (transformProgress.isEmpty()) {
+        transformComplete = true;
+      }
+      if (indexProgress.isEmpty()) {
+        indexComplete = true;
+      }
+    }
+
+    if (!(filterComplete && transformComplete && indexComplete)) {
       setTick();
     }
   }
@@ -123,7 +171,7 @@ public class WarcProgressManager {
   }
 
   public boolean hasErrors() {
-    return !errorQ.isEmpty() || discardedErrors > 0;
+    return !errorQ.isEmpty() || discardedErrors > 0 || loadingFailed;
   }
 
   public boolean finishedWithoutError() {
@@ -175,7 +223,27 @@ public class WarcProgressManager {
     return indexComplete;
   }
 
+  public int getCountFilterCompleted() {
+    return countFilterCompleted;
+  }
+
+  public int getCountTransformCompleted() {
+    return countTransformCompleted;
+  }
+
+  public int getCountIndexCompleted() {
+    return countIndexCompleted;
+  }
+
   public int size() {
     return batchSize;
+  }
+
+  public long getBatchBytes() {
+    return batchBytes;
+  }
+
+  public void setBatchBytes(long batchBytes) {
+    this.batchBytes = batchBytes;
   }
 }

--- a/src/bamboo/trove/common/WarcSummary.java
+++ b/src/bamboo/trove/common/WarcSummary.java
@@ -1,0 +1,100 @@
+package bamboo.trove.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This class exists solely for ferrying data between the App server and the dashboard. We don't won't to be
+ * serializing all of a Warc's data every time the UI ajax tick fires so this minimal summary object carries
+ * only what is required. The heaviest work required is when errors exist... but we can accept that edge case.
+ */
+public class WarcSummary {
+  @JsonIgnore
+  private WarcProgressManager warc;
+
+  public WarcSummary(WarcProgressManager warc) {
+    this.warc = warc;
+  }
+
+  @JsonProperty("warcId")
+  public long getWarcId() {
+    return warc.getWarcId();
+  }
+
+  @JsonProperty("timeStarted")
+  public long getTimeStarted() {
+    return warc.getTimeStarted();
+  }
+
+  @JsonProperty("loadComplete")
+  public boolean isLoadComplete() {
+    return warc.isLoadingComplete();
+  }
+
+  @JsonProperty("loadFailed")
+  public boolean isLoadFailed() {
+    return warc.isLoadingFailed();
+  }
+
+  @JsonProperty("documentCount")
+  public int getDocumentCount() {
+    return warc.size();
+  }
+
+  @JsonProperty("warcBytes")
+  public long getWarcBytes() {
+    return warc.getBatchBytes();
+  }
+
+  @JsonProperty("countFilter")
+  public int getCountFilter() {
+    return warc.getCountFilterCompleted();
+  }
+
+  @JsonProperty("countTransform")
+  public int getCountTransform() {
+    return warc.getCountTransformCompleted();
+  }
+
+  @JsonProperty("countIndex")
+  public int getCountIndex() {
+    return warc.getCountIndexCompleted();
+  }
+
+  @JsonProperty("hasError")
+  public boolean getHasError() {
+    return warc.hasErrors();
+  }
+
+  private static final List<String> noErrors = new ArrayList<>(0);
+  @JsonProperty("getErrors")
+  public List<String> getErrors() {
+    if (warc.errorQ.isEmpty()) {
+      return noErrors;
+    }
+
+    List<String> errors = new ArrayList<>();
+    for (IndexerDocument doc : warc.errorQ) {
+      String errorMessage = "Doc '" + doc.getDocId() + "' in error: ";
+      if (doc.getFilterError() != null) {
+        errorMessage += "Filter error: " + doc.getFilterError().getMessage();
+      }
+      if (doc.getTransformError() != null) {
+        errorMessage += "Transform error: " + doc.getTransformError().getMessage();
+      }
+      if (doc.getIndexError() != null) {
+        errorMessage += "Filter error: " + doc.getIndexError().getMessage();
+      }
+      errors.add(errorMessage);
+    }
+    return errors;
+  }
+
+  @JsonProperty("discardedErrors")
+  public int getDiscardedErrors() {
+    return warc.discardedErrors;
+  }
+}

--- a/src/bamboo/trove/common/WarcSummary.java
+++ b/src/bamboo/trove/common/WarcSummary.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.common;
 
 import java.util.ArrayList;

--- a/src/bamboo/trove/demand/OnDemandWarcManager.java
+++ b/src/bamboo/trove/demand/OnDemandWarcManager.java
@@ -57,16 +57,19 @@ public class OnDemandWarcManager extends BaseWarcDomainManager {
 
     while (!batch.isFilterComplete()) {
       Thread.sleep(100);
+      checkErrors(batch);
     }
     log.info("Warc #{} has finished filtering...", warcId);
 
     while (!batch.isTransformComplete()) {
       Thread.sleep(100);
+      checkErrors(batch);
     }
     log.info("Warc #{} has finished transform...", warcId);
 
     while (!batch.isIndexComplete()) {
       Thread.sleep(100);
+      checkErrors(batch);
     }
     log.info("Warc #{} has finished indexing...", warcId);
 
@@ -74,6 +77,13 @@ public class OnDemandWarcManager extends BaseWarcDomainManager {
     lastWarcId = warcId;
 
     return ClientUtils.toXML(responseDocument.getSolrDocument());
+  }
+
+  private void checkErrors(WarcProgressManager warc) throws Exception {
+    if (warc.hasErrors()) {
+      log.error("Warc #{} failed to index.", warc.getWarcId());
+      throw new Exception("Indexing failed");
+    }
   }
 
   public void run() {

--- a/src/bamboo/trove/demand/OnDemandWarcManager.java
+++ b/src/bamboo/trove/demand/OnDemandWarcManager.java
@@ -1,6 +1,20 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.demand;
 
-import java.util.Iterator;
 import javax.annotation.PostConstruct;
 
 import bamboo.trove.common.BaseWarcDomainManager;
@@ -37,41 +51,34 @@ public class OnDemandWarcManager extends BaseWarcDomainManager {
     }
 
     log.info("Indexing on demand. Warc #{}", warcId);
-    WarcProgressManager batch = getWarcFromBamboo(warcId);
-    IndexerDocument responseDocument = batch.getFilterQ().peek();
-    if (warcOffset < -1) {
-      String target = warcId + "/" + warcOffset;
-      Iterator<IndexerDocument> i = batch.getFilterQ().iterator();
-      while (i.hasNext() && !target.equals(responseDocument.getDocId())) {
-        responseDocument = i.next();
-      }
-      if (!target.equals(responseDocument.getDocId())) {
-        return "<error>Warc Offest " + warcOffset + " could not be found in warc #" + warcId + "</error>";
-      }
-    }
-
-    log.info("Warc #{} has {} documents. Starting filtering...", warcId, batch.size());
-    enqueueBatch(batch);
+    WarcProgressManager batch = getAndEnqueueWarc(warcId, warcOffset);
+    IndexerDocument responseDocument = batch.getTrackedDocument();
+    log.info("Warc #{} has {} documents. Loading has completed.", warcId, batch.size());
 
     while (!batch.isFilterComplete()) {
       Thread.sleep(100);
     }
-    log.info("Warc #{} has finished filtering. Starting tranform...", warcId);
+    log.info("Warc #{} has finished filtering...", warcId);
 
     while (!batch.isTransformComplete()) {
       Thread.sleep(100);
     }
-    log.info("Warc #{} has finished transform. Starting indexing...", warcId);
+    log.info("Warc #{} has finished transform...", warcId);
 
     while (!batch.isIndexComplete()) {
       Thread.sleep(100);
     }
-    log.info("Warc #{} has finished indexing.", warcId);
+    log.info("Warc #{} has finished indexing...", warcId);
 
     warcsProcessed++;
     lastWarcId = warcId;
 
     return ClientUtils.toXML(responseDocument.getSolrDocument());
+  }
+
+  public void run() {
+    // Doesn't really do anything
+    start();
   }
 
   @Override

--- a/src/bamboo/trove/full/FullReindexWarcManager.java
+++ b/src/bamboo/trove/full/FullReindexWarcManager.java
@@ -1,8 +1,32 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.full;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.PostConstruct;
 
 import au.gov.nla.trove.indexer.api.EndPointDomainManager;
+import au.gov.nla.trove.indexer.api.WorkProcessor;
 import bamboo.trove.common.BaseWarcDomainManager;
 import bamboo.trove.common.WarcProgressManager;
 import bamboo.trove.services.FilteringCoordinationService;
@@ -16,6 +40,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class FullReindexWarcManager extends BaseWarcDomainManager {
   private static final Logger log = LoggerFactory.getLogger(FullReindexWarcManager.class);
+  private static final int POLL_INTERVAL_SECONDS = 1;
 
   private long warcMin = 127536;
   private long warcMax = 127773;
@@ -34,8 +59,26 @@ public class FullReindexWarcManager extends BaseWarcDomainManager {
 
   private boolean running = false;
   private boolean stopping = false;
+  private boolean finishedFinding = false;
   private long warcsProcessed = 0;
   private long lastWarcId = warcMin - 1;
+
+  private WorkProcessor readPool;
+  private List<ReadWorker> readWorkers = new ArrayList<>();
+  private int bambooReadThreads = 1;
+  private Queue<Long> warcIdQueue = new ConcurrentLinkedQueue<>();
+
+  private Map<Long, WarcProgressManager> warcTracking = new TreeMap<>();
+  private int queueLimit = 5;
+  private Timer timer;
+
+  public void setBambooReadThreads(int bambooReadThreads) {
+    this.bambooReadThreads = bambooReadThreads;
+  }
+
+  public void setQueueLimit(int queueLimit) {
+    this.queueLimit = queueLimit;
+  }
 
   @Required
   public void setBambooBaseUrl(String bambooBaseUrl) {
@@ -62,7 +105,33 @@ public class FullReindexWarcManager extends BaseWarcDomainManager {
 		log.info("***** FullReindexWarcManager *****");
     BaseWarcDomainManager.startMe(bambooBaseUrl, maxFilterWorkers, maxTransformWorkers, maxIndexWorkers,
             solrManager, filteringService);
+    log.info("Warc read threads : {}", bambooReadThreads);
+    log.info("Warc queue limit  : {}", queueLimit);
     log.info("Run at start      : {}", runAtStart);
+    readPool = new WorkProcessor(bambooReadThreads);
+    checkBatches();
+  }
+
+  private void startWorkers() {
+    for (int i = 0; i < bambooReadThreads; i++) {
+      ReadWorker worker = new ReadWorker();
+      readWorkers.add(worker);
+      readPool.process(worker);
+    }
+  }
+
+  private void stopWorkers() {
+    // Tell each worker to stop
+    for (int i = 0; i < bambooReadThreads; i++) {
+      readWorkers.get(0).stop();
+      // Then dereference them from the domain
+      readWorkers.remove(0);
+    }
+    // Wait until the thread confirms they all stopped
+    readPool.stop();
+
+    running = false;
+    stopping = false;
   }
 
   @Override
@@ -80,14 +149,25 @@ public class FullReindexWarcManager extends BaseWarcDomainManager {
     if (!running && !stopping)  {
       log.info("Starting...");
       running = true;
-      loop();
+      Thread me = new Thread(this);
+      me.setName(getName());
+      me.start();
     }
+  }
+
+  public void run() {
+    startWorkers();
+    loop();
   }
 
   @Override
   public void stop() {
     if (running && !stopping)  {
+      if (timer != null) {
+        timer.cancel();
+      }
       stopping = true;
+      stopWorkers();
     }
   }
 
@@ -106,26 +186,104 @@ public class FullReindexWarcManager extends BaseWarcDomainManager {
     return "warc#" + lastWarcId;
   }
 
+
   private void loop() {
-    while (!stopping) {
-      doWork();
+    while (running && !stopping&& !finishedFinding) {
+      try {
+        doWork();
+      } catch (InterruptedException e) {
+        log.error("Thread sleep interrupted whilst waiting on batch completion. Resuming: {}", e.getMessage());
+      }
     }
-    running = false;
-    stopping = false;
   }
 
-  private void doWork() {
-    enqueueBatch(getNextWarc());
-  }
-
-  private WarcProgressManager getNextWarc() {
+  private void doWork() throws InterruptedException {
+    // Work complete
     if ((lastWarcId + 1) > warcMax) {
-      stopping = true;
-      return null;
+      finishedFinding = true;
+      return;
     }
-    WarcProgressManager result = getWarcFromBamboo(lastWarcId + 1);
-    log.info("Warc #{} retrieved. {} docs", lastWarcId + 1, result.size());
+    // Saturated queue
+    if ((warcTracking.size() + warcIdQueue.size()) >= queueLimit) {
+      Thread.sleep(1000);
+      return;
+    }
+
+    log.info("Enqueueing {}", lastWarcId + 1);
+    warcIdQueue.offer(lastWarcId + 1);
     lastWarcId++;
-    return result;
+  }
+
+  private void setTick() {
+    if (timer == null) {
+      timer = new Timer();
+    }
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        checkBatches();
+      }
+    }, POLL_INTERVAL_SECONDS * 1000);
+  }
+
+  private void checkBatches() {
+    // Check state
+    List<Long> completedWarcs = new ArrayList<>();
+    for (Long key : warcTracking.keySet()) {
+      WarcProgressManager warc = warcTracking.get(key);
+      if (warc.finishedWithoutError()) {
+        completedWarcs.add(key);
+      } else {
+        if (warc.finished()) {
+          log.error("Warc {} is completed but has errors!", key);
+        }
+      }
+    }
+
+    // Cleanup
+    for (Long warcId : completedWarcs) {
+      log.info("De-referencing completed warc: {}", warcId);
+      warcTracking.remove(warcId);
+    }
+
+    // Keep going unless we are done
+    if (!(finishedFinding && warcTracking.isEmpty())) {
+      setTick();
+    } else {
+      stop();
+    }
+  }
+
+  private class ReadWorker implements Runnable {
+    private boolean stop = false;
+
+    @Override
+    public void run() {
+      log.info("Worker thread starting.");
+      // TODO : full lifecycle needs more work. Stop/Start etc. This one just runs once
+      while (!stop) {
+        // Find work
+        Long warcId = warcIdQueue.poll();
+        if (warcId == null) {
+          try {
+            Thread.sleep(1000);
+          } catch (InterruptedException e) {
+            log.error("Caught exception: ", e);
+          }
+          continue;
+        }
+        log.info("Seeking warc {}", warcId);
+        // Do work
+        WarcProgressManager batch = getAndEnqueueWarc(warcId);
+        log.info("Warc #{} retrieval complete. {} docs", warcId, batch.size());
+        // Track state
+        warcTracking.put(warcId, batch);
+      }
+      log.info("Worker thread exiting.");
+    }
+
+    public void stop() {
+      stop = true;
+    }
   }
 }

--- a/src/bamboo/trove/services/BambooRestrictionService.java
+++ b/src/bamboo/trove/services/BambooRestrictionService.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.services;
 
 import java.util.ArrayList;

--- a/src/bamboo/trove/services/FilteringCoordinationService.java
+++ b/src/bamboo/trove/services/FilteringCoordinationService.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.services;
 
 import java.util.HashMap;

--- a/src/bamboo/trove/services/QualityControlService.java
+++ b/src/bamboo/trove/services/QualityControlService.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.services;
 
 import bamboo.task.Document;

--- a/src/bamboo/trove/workers/FilterWorker.java
+++ b/src/bamboo/trove/workers/FilterWorker.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.workers;
 
 import bamboo.trove.common.BaseWarcDomainManager;
@@ -12,6 +27,8 @@ public class FilterWorker implements Runnable {
 
   private FilteringCoordinationService filteringService;
   private Timer timer;
+  private IndexerDocument lastJob = null;
+  private IndexerDocument thisJob = null;
 
   public FilterWorker(FilteringCoordinationService filteringService, Timer timer) {
     this.filteringService = filteringService;
@@ -24,13 +41,11 @@ public class FilterWorker implements Runnable {
   }
 
   public boolean loop() {
-    IndexerDocument job = null;
     try {
-      job = findJob();
-      doJob(job);
-      // Make sure we de-reference to ensure that an exception thrown inside findJob()
-      // doesn't flag the error from last time through the loop
-      job = null;
+      findJob();
+      doJob();
+      lastJob = thisJob;
+      thisJob = null;
 
     } catch (InterruptedException ex) {
       log.error("Thread.Sleep() interrupted on worker that cannot find job. Resuming. MSG:'{}'", ex.getMessage());
@@ -38,25 +53,25 @@ public class FilterWorker implements Runnable {
 
     } catch (Exception ex) {
       log.error("Unexpected error during FilterWorker execution: ", ex);
-      if (job != null) {
-        job.setTransformError(ex);
+      if (thisJob != null) {
+        thisJob.setTransformError(ex);
       }
     }
     return true;
   }
 
-  private IndexerDocument findJob() throws InterruptedException {
-    IndexerDocument filterJob = BaseWarcDomainManager.getNextFilterJob();
-    while (filterJob == null) {
+  private void findJob() throws InterruptedException {
+    thisJob = BaseWarcDomainManager.getNextFilterJob(lastJob);
+    lastJob = null;
+    while (thisJob == null) {
       Thread.sleep(1000);
-      filterJob = BaseWarcDomainManager.getNextFilterJob();
+      thisJob = BaseWarcDomainManager.getNextFilterJob(null);
     }
-    return filterJob;
   }
 
-  private void doJob(IndexerDocument document) {
-    document.filter.start(timer);
-    filteringService.filterDocument(document);
-    document.filter.finish();
+  private void doJob() {
+    thisJob.filter.start(timer);
+    filteringService.filterDocument(thisJob);
+    thisJob.filter.finish();
   }
 }

--- a/src/bamboo/trove/workers/FilterWorker.java
+++ b/src/bamboo/trove/workers/FilterWorker.java
@@ -54,8 +54,10 @@ public class FilterWorker implements Runnable {
     } catch (Exception ex) {
       log.error("Unexpected error during FilterWorker execution: ", ex);
       if (thisJob != null) {
-        thisJob.setTransformError(ex);
+        thisJob.setFilterError(ex);
       }
+      lastJob = thisJob;
+      thisJob = null;
     }
     return true;
   }
@@ -71,6 +73,9 @@ public class FilterWorker implements Runnable {
 
   private void doJob() {
     thisJob.filter.start(timer);
+    if (thisJob.getDocId().equals("127536/2502")) {
+      throw new IllegalStateException("I was instructed to failed on object 127536/2502 for testing purposes");
+    }
     filteringService.filterDocument(thisJob);
     thisJob.filter.finish();
   }

--- a/src/bamboo/trove/workers/IndexerWorker.java
+++ b/src/bamboo/trove/workers/IndexerWorker.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.workers;
 
 import au.gov.nla.trove.indexer.api.EndPointDomainManager;
@@ -15,6 +30,8 @@ public class IndexerWorker implements Runnable {
   private EndPointDomainManager solrManager;
   private Timer timer;
   private Timer dqTimer;
+  private IndexerDocument lastJob = null;
+  private IndexerDocument thisJob = null;
 
   public IndexerWorker(EndPointDomainManager solrManager, Timer timer) {
     this.solrManager = solrManager;
@@ -35,13 +52,9 @@ public class IndexerWorker implements Runnable {
   }
 
   public boolean loop() {
-    IndexerDocument job = null;
     try {
-      job = findJob();
-      doJob(job);
-      // Make sure we de-reference to ensure that an exception thrown inside findJob()
-      // doesn't flag the error from last time through the loop
-      job = null;
+      findJob();
+      doJob();
 
     } catch (InterruptedException ex) {
       log.error("Thread.Sleep() interrupted on worker that cannot find job. Resuming. MSG:'{}'", ex.getMessage());
@@ -49,32 +62,34 @@ public class IndexerWorker implements Runnable {
 
     } catch (Exception ex) {
       log.error("Unexpected error during IndexerWorker execution: ", ex);
-      if (job != null) {
-        job.setIndexError(ex);
+      if (thisJob != null) {
+        thisJob.setIndexError(ex);
       }
     }
+    lastJob = thisJob;
+    thisJob = null;
     return true;
   }
 
-  private IndexerDocument findJob() throws InterruptedException {
-    IndexerDocument job = BaseWarcDomainManager.getNextIndexJob();
-    while (job == null) {
+  private void findJob() throws InterruptedException {
+    thisJob = BaseWarcDomainManager.getNextIndexJob(lastJob);
+    lastJob = null;
+    while (thisJob == null) {
       Thread.sleep(1000);
-      job = BaseWarcDomainManager.getNextIndexJob();
+      thisJob = BaseWarcDomainManager.getNextIndexJob(null);
     }
-    return job;
   }
 
-  private void doJob(IndexerDocument document) {
+  private void doJob() {
     Timer.Context ctx = dqTimer.time();
     try {
-      document.index.start(timer);
-      if (document.getTheshold().equals(ContentThreshold.NONE)) {
-        document.index.finish();
+      thisJob.index.start(timer);
+      if (thisJob.getTheshold().equals(ContentThreshold.NONE)) {
+        thisJob.index.finish();
         return;
       }
       // IndexerDocument implements AcknowledgeWorker so it will handle the timer.stop() and/or errors
-      solrManager.add(document.getSolrDocument(), document);
+      solrManager.add(thisJob.getSolrDocument(), thisJob);
 
     } finally {
       ctx.stop();

--- a/src/bamboo/trove/workers/IndexerWorker.java
+++ b/src/bamboo/trove/workers/IndexerWorker.java
@@ -84,7 +84,8 @@ public class IndexerWorker implements Runnable {
     Timer.Context ctx = dqTimer.time();
     try {
       thisJob.index.start(timer);
-      if (thisJob.getTheshold().equals(ContentThreshold.NONE)) {
+      if (thisJob.getTheshold() == null || thisJob.getSolrDocument() == null
+              || thisJob.getTheshold().equals(ContentThreshold.NONE)) {
         thisJob.index.finish();
         return;
       }

--- a/src/bamboo/trove/workers/TransformWorker.java
+++ b/src/bamboo/trove/workers/TransformWorker.java
@@ -57,6 +57,8 @@ public class TransformWorker implements Runnable {
       if (thisJob != null) {
         thisJob.setTransformError(ex);
       }
+      lastJob = thisJob;
+      thisJob = null;
     }
     return true;
   }
@@ -89,7 +91,18 @@ public class TransformWorker implements Runnable {
     solr.addField(SolrEnum.TITLE.toString(), document.getBambooDocument().getTitle());
     solr.addField(SolrEnum.CONTENT_TYPE.toString(), document.getBambooDocument().getContentType());
     solr.addField(SolrEnum.SITE.toString(), document.getBambooDocument().getSite());
-    solr.addField(SolrEnum.RESTRICTED.toString(), DocumentStatus.RESTRICTED.equals(document.getStatus()));
+    if (DocumentStatus.RESTRICTED_FOR_BOTH.equals(document.getStatus())) {
+      solr.addField(SolrEnum.DELIVERABLE.toString(), false);
+      solr.addField(SolrEnum.DISCOVERABLE.toString(), false);
+    }
+    if (DocumentStatus.RESTRICTED_FOR_DELIVERY.equals(document.getStatus())) {
+      solr.addField(SolrEnum.DELIVERABLE.toString(), false);
+      solr.addField(SolrEnum.DISCOVERABLE.toString(), true);
+    }
+    if (DocumentStatus.RESTRICTED_FOR_DISCOVERY.equals(document.getStatus())) {
+      solr.addField(SolrEnum.DELIVERABLE.toString(), true);
+      solr.addField(SolrEnum.DISCOVERABLE.toString(), false);
+    }
 
     if (ContentThreshold.METADATA_ONLY.equals(document.getTheshold())) {
       document.converted(solr);

--- a/src/bamboo/trove/workers/TransformWorker.java
+++ b/src/bamboo/trove/workers/TransformWorker.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 National Library of Australia
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bamboo.trove.workers;
 
 import bamboo.trove.common.BaseWarcDomainManager;
@@ -14,6 +29,8 @@ public class TransformWorker implements Runnable {
   private static Logger log = LoggerFactory.getLogger(TransformWorker.class);
 
   private Timer timer;
+  private IndexerDocument lastJob = null;
+  private IndexerDocument thisJob = null;
 
   public TransformWorker(Timer timer) {
     this.timer = timer;
@@ -25,13 +42,11 @@ public class TransformWorker implements Runnable {
   }
 
   public boolean loop() {
-    IndexerDocument job = null;
     try {
-      job = findJob();
-      doJob(job);
-      // Make sure we de-reference to ensure that an exception thrown inside findJob()
-      // doesn't flag the error from last time through the loop
-      job = null;
+      findJob();
+      doJob();
+      lastJob = thisJob;
+      thisJob = null;
 
     } catch (InterruptedException ex) {
       log.error("Thread.Sleep() interrupted on worker that cannot find job. Resuming. MSG:'{}'", ex.getMessage());
@@ -39,26 +54,26 @@ public class TransformWorker implements Runnable {
 
     } catch (Exception ex) {
       log.error("Unexpected error during TransformWorker execution: ", ex);
-      if (job != null) {
-        job.setTransformError(ex);
+      if (thisJob != null) {
+        thisJob.setTransformError(ex);
       }
     }
     return true;
   }
 
-  private IndexerDocument findJob() throws InterruptedException {
-    IndexerDocument job = BaseWarcDomainManager.getNextTransformJob();
-    while (job == null) {
+  private void findJob() throws InterruptedException {
+    thisJob = BaseWarcDomainManager.getNextTransformJob(lastJob);
+    lastJob = null;
+    while (thisJob == null) {
       Thread.sleep(1000);
-      job = BaseWarcDomainManager.getNextTransformJob();
+      thisJob = BaseWarcDomainManager.getNextTransformJob(null);
     }
-    return job;
   }
 
-  private void doJob(IndexerDocument document) {
-    document.transform.start(timer);
-    transform(document);
-    document.transform.finish();
+  private void doJob() {
+    thisJob.transform.start(timer);
+    transform(thisJob);
+    thisJob.transform.finish();
   }
 
   private void transform(IndexerDocument document) {

--- a/test/bamboo/trove/TroveIndexerTest.java
+++ b/test/bamboo/trove/TroveIndexerTest.java
@@ -225,7 +225,7 @@ public class TroveIndexerTest {
 
     // Filtering
     startWithAssertions(document.filter, timer);
-    document.applyFiltering(DocumentStatus.RESTRICTED, ContentThreshold.DOCUMENT_START_ONLY);
+    document.applyFiltering(DocumentStatus.RESTRICTED_FOR_BOTH, ContentThreshold.DOCUMENT_START_ONLY);
     document.filter.finish();
 
     // Working


### PR DESCRIPTION
Adding license boilerplates. Removing integration test with reference to devel server. Expanding on the stub feeding work through the front door of the domains... it should now scale much higher by disconnecting batches from the worker pools and starting work on documents as soon as the batch begins streaming in.
